### PR TITLE
Replace lazy_static  with std::sync::LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,14 +3,5 @@
 version = 4
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "vintagecc"
 version = "0.1.0"
-dependencies = [
- "lazy_static",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-lazy_static = "1.5.0"

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -1,17 +1,18 @@
 #![allow(static_mut_refs)]
 
-use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
-lazy_static!{
-	static ref ARR8_INDICES:   Mutex<HashMap<String, usize>> = Mutex::new(HashMap::new());
-	static ref ARR16_INDICES:  Mutex<HashMap<String, usize>> = Mutex::new(HashMap::new());
-	static ref VAR_INDICES:    Mutex<HashMap<String, usize>> = Mutex::new(HashMap::new());
-	static ref IFBLK_HAS_ELSE: Mutex<HashMap<String, bool>>  = Mutex::new(HashMap::new());
-}
+static ARR8_INDICES: LazyLock<Mutex<HashMap<String, usize>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static ARR16_INDICES: LazyLock<Mutex<HashMap<String, usize>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static VAR_INDICES: LazyLock<Mutex<HashMap<String, usize>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static IFBLK_HAS_ELSE: LazyLock<Mutex<HashMap<String, bool>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 static mut ACTIVE_FN:       String = String::new();
 static mut PLATFORM:        String = String::new();


### PR DESCRIPTION
Cool project!

 In rust 1.7 or later new lazy loading std libs were added, so you actually don't need lazy_static! anymore.
 
 A suggestion, you can improve vintage-cc compile time performance as well as binary size of the compiler with adding this snippet in your cargo.toml.
 
 [profile.release]
opt-level = 3
lto = "fat"
codegen-units = 1
panic = "abort" 
strip = "symbols"
